### PR TITLE
chore: bump electron-notarize to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@electron/get": "^1.6.0",
     "asar": "^3.0.0",
     "debug": "^4.0.1",
-    "electron-notarize": "^1.0.0",
+    "electron-notarize": "^1.1.1",
     "electron-osx-sign": "^0.5.0",
     "extract-zip": "^2.0.0",
     "filenamify": "^4.1.0",


### PR DESCRIPTION
Bumps electron-notarize to 1.1.1 which supports `notarytool` - the new notarization tool of XCode 13.
